### PR TITLE
Correction of default function name

### DIFF
--- a/editor/initial_code/python_27
+++ b/editor/initial_code/python_27
@@ -6,7 +6,7 @@ SNAKE = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
 EMPTY = "."
 
 
-def checkio(field_map):
+def snake(field_map):
     return "F" or "R" or "L" or "FRL"
 
 

--- a/editor/initial_code/python_3
+++ b/editor/initial_code/python_3
@@ -6,7 +6,7 @@ SNAKE = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
 EMPTY = "."
 
 
-def checkio(field_map):
+def snake(field_map):
     return "F" or "R" or "L" or "FRL"
 
 


### PR DESCRIPTION
Expected function name became 'snake' in referee code, but it stayed to
'checkio' in default code template.
